### PR TITLE
fix: added dynamic RG selection and improved validation checks for VM statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The application accepts several flags:
   can be useful when running the application behind a reverse proxy.
 - `--provider`: cloud provider to use (default is `aws`).
 - `--resource-group-name`: optional flag to specify an Azure resource group for VM filtering.
-(default retrieves VMs from all resource groups for the specified subscription)
+  (default retrieves VMs from all resource groups for the specified subscription)
 - `--subscription-id`: subscription ID to use (required for Azure).
 - `-t, --tags`: filter instances using tag key-value pairs (e.g.,
   `Environment=dev,Name=dev.example.com`).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Use the Azure cloud provider and filter on instances that have both tag key
 ```bash
 river-guide --provider azure \
             --tags "Environment=dev,DashboardManageable=true" \
-            --resource-group-name "my-resource-group" \
             --subscription-id "00000000-0000-0000-0000-000000000000"
 ```
 
@@ -119,8 +118,7 @@ The application accepts several flags:
 - `--path-prefix`: path prefix for the application (default is `/`). This
   can be useful when running the application behind a reverse proxy.
 - `--provider`: cloud provider to use (default is `aws`).
-- `--resource-group-name`: name of the resource group to use (required for
-  Azure).
+- `--resource-group-name`: name of the resource group to use for azure (default queried from subscription ID).
 - `--subscription-id`: subscription ID to use (required for Azure).
 - `-t, --tags`: filter instances using tag key-value pairs (e.g.,
   `Environment=dev,Name=dev.example.com`).

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ The application accepts several flags:
 - `--path-prefix`: path prefix for the application (default is `/`). This
   can be useful when running the application behind a reverse proxy.
 - `--provider`: cloud provider to use (default is `aws`).
-- `--resource-group-name`: name of the resource group to use for azure (default queried from subscription ID).
+- `--resource-group-name`: optional flag to specify an Azure resource group for VM filtering.
+(default retrieves VMs from all resource groups for the specified subscription)
 - `--subscription-id`: subscription ID to use (required for Azure).
 - `-t, --tags`: filter instances using tag key-value pairs (e.g.,
   `Environment=dev,Name=dev.example.com`).

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ key "Environment" and value "dev" and tag key "DashboardManageable" and value
 AWS_REGION=us-west-2 river-guide --tags "Environment=dev,DashboardManageable=true"
 ```
 
-Use the Azure cloud provider and filter on instances that have both tag key
-"Environment" and value "dev" and tag key "DashboardManageable" and value
-"true".
+Use the Azure cloud provider and filter on instances in the "my-resource-group"
+resource group having both tag key "Environment" and value "dev" and tag key
+"DashboardManageable" and value "true".
 
 ```bash
 river-guide --provider azure \

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The application accepts several flags:
 - `--path-prefix`: path prefix for the application (default is `/`). This
   can be useful when running the application behind a reverse proxy.
 - `--provider`: cloud provider to use (default is `aws`).
-- `--resource-group-name`: optional flag to specify an Azure resource group for VM filtering.
-  (default retrieves VMs from all resource groups for the specified subscription)
+- `--resource-group-name`: filter instances based on their resource group membership
+  (only used with the Azure provider).
 - `--subscription-id`: subscription ID to use (required for Azure).
 - `-t, --tags`: filter instances using tag key-value pairs (e.g.,
   `Environment=dev,Name=dev.example.com`).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Use the Azure cloud provider and filter on instances that have both tag key
 ```bash
 river-guide --provider azure \
             --tags "Environment=dev,DashboardManageable=true" \
+            --resource-group-name "my-resource-group" \
             --subscription-id "00000000-0000-0000-0000-000000000000"
 ```
 

--- a/cmd/assets/index.gohtml
+++ b/cmd/assets/index.gohtml
@@ -19,6 +19,11 @@
 			color: {{ .PrimaryColor }};
 		}
 
+		h3 {
+			text-align: center;
+			color: {{ .PrimaryColor }};
+		}
+
 		.container {
 			max-width: 600px;
 			margin: 0 auto;
@@ -152,6 +157,10 @@
 <body>
 	<div class="container">
 		<h1>{{ .Title }}</h1>
+		<h3> Provider: {{.Provider}} </h3>
+		{{if and (eq .Provider "azure") .SpecifiedResourceGroup}}
+			<h3>Specified Resource Group: {{.SpecifiedResourceGroup}}</h3>
+		{{end}}
 		<div class="action-container">
 			<button onclick="toggleServer()">{{.ActionText}}</button>
 			<div id="loading-indicator"></div>

--- a/cmd/assets/index.gohtml
+++ b/cmd/assets/index.gohtml
@@ -19,11 +19,6 @@
 			color: {{ .PrimaryColor }};
 		}
 
-		h3 {
-			text-align: center;
-			color: {{ .PrimaryColor }};
-		}
-
 		.container {
 			max-width: 600px;
 			margin: 0 auto;
@@ -157,7 +152,6 @@
 <body>
 	<div class="container">
 		<h1>{{ .Title }}</h1>
-		<h3> Provider: {{.Provider}} </h3>
 		<div class="action-container">
 			<button onclick="toggleServer()">{{.ActionText}}</button>
 			<div id="loading-indicator"></div>

--- a/cmd/assets/index.gohtml
+++ b/cmd/assets/index.gohtml
@@ -158,9 +158,6 @@
 	<div class="container">
 		<h1>{{ .Title }}</h1>
 		<h3> Provider: {{.Provider}} </h3>
-		{{if and (eq .Provider "azure") .SpecifiedResourceGroup}}
-			<h3>Specified Resource Group: {{.SpecifiedResourceGroup}}</h3>
-		{{end}}
 		<div class="action-container">
 			<button onclick="toggleServer()">{{.ActionText}}</button>
 			<div id="loading-indicator"></div>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,7 +97,7 @@ func init() {
 	rootCmd.Flags().Duration("read-header-timeout", defaultReadHeaderTimeout, "timeout for reading the request headers")
 	rootCmd.Flags().String("provider", "aws", "cloud provider (aws or azure)")
 	rootCmd.Flags().String("resource-group-name", "", "filter instances based on their resource group membership (only used with the Azure provider)")
-	rootCmd.Flags().String("subscription-id", "", "subscription ID (valid only for Azure)")
+	rootCmd.Flags().String("subscription-id", "", "subscription ID (required for Azure)")
 
 	err := viper.BindPFlags(rootCmd.Flags())
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 	rootCmd.Flags().String("favicon", "", "path to favicon")
 	rootCmd.Flags().Duration("read-header-timeout", defaultReadHeaderTimeout, "timeout for reading the request headers")
 	rootCmd.Flags().String("provider", "aws", "cloud provider (aws or azure)")
-	rootCmd.Flags().String("resource-group-name", "", "default resource group name (valid only for Azure)")
+	rootCmd.Flags().String("resource-group-name", "", "optional resource group name filter (valid only for Azure)")
 	rootCmd.Flags().String("subscription-id", "", "subscription ID (valid only for Azure)")
 
 	err := viper.BindPFlags(rootCmd.Flags())
@@ -468,23 +468,21 @@ func (h *APIHandler) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	type TemplateData struct {
-		Title                  string
-		ActionText             string
-		PrimaryColor           string
-		TogglePath             string
-		Provider               string
-		SpecifiedResourceGroup string
-		Servers                []*Server
+		Title        string
+		ActionText   string
+		PrimaryColor string
+		TogglePath   string
+		Provider     string
+		Servers      []*Server
 	}
 
 	data := TemplateData{
-		Title:                  viper.GetString("title"),
-		Servers:                sb.Servers,
-		ActionText:             "Pending",
-		PrimaryColor:           viper.GetString("primary-color"),
-		Provider:               viper.GetString("provider"),
-		SpecifiedResourceGroup: viper.GetString("resource-group-name"),
-		TogglePath:             filepath.Join(viper.GetString("path-prefix"), "toggle"),
+		Title:        viper.GetString("title"),
+		Servers:      sb.Servers,
+		ActionText:   "Pending",
+		PrimaryColor: viper.GetString("primary-color"),
+		Provider:     viper.GetString("provider"),
+		TogglePath:   filepath.Join(viper.GetString("path-prefix"), "toggle"),
 	}
 	status := sb.GetStatus()
 	if status == string(types.InstanceStateNameRunning) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -472,7 +472,6 @@ func (h *APIHandler) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		ActionText   string
 		PrimaryColor string
 		TogglePath   string
-		Provider     string
 		Servers      []*Server
 	}
 
@@ -481,7 +480,6 @@ func (h *APIHandler) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		Servers:      sb.Servers,
 		ActionText:   "Pending",
 		PrimaryColor: viper.GetString("primary-color"),
-		Provider:     viper.GetString("provider"),
 		TogglePath:   filepath.Join(viper.GetString("path-prefix"), "toggle"),
 	}
 	status := sb.GetStatus()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,9 +51,8 @@ import (
 )
 
 var (
-	cfgFile           string
-	resourceGroupName string
-	subscriptionID    string
+	cfgFile        string
+	subscriptionID string
 )
 
 const (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,9 +168,10 @@ func (a *AzureProvider) GetStatus() string {
 
 // Server represents an AWS EC2 or Azure VM server.
 type Server struct {
-	Name   string
-	ID     *string
-	Status string
+	Name              string
+	ID                *string
+	Status            string
+	ResourceGroupName string
 }
 
 // ServerBank represents a bank of AWS servers.
@@ -263,6 +264,8 @@ func (h *AWSProvider) GetServerBank(tags map[string]string) (*ServerBank, error)
 // GetServerBank queries Azure VM instances based on the specified tags.
 func (a *AzureProvider) GetServerBank(tags map[string]string) (*ServerBank, error) {
 	ctx := context.TODO()
+	specifiedResourceGroupName := viper.GetString("resource-group-name")
+
 	pager := a.vmClient.NewListAllPager(nil)
 	serverBank := &ServerBank{}
 
@@ -274,6 +277,10 @@ func (a *AzureProvider) GetServerBank(tags map[string]string) (*ServerBank, erro
 
 		// manual filter by tag
 		for _, vm := range result.Value {
+			resourceGroupName := specifiedResourceGroupName
+			if resourceGroupName == "" {
+				resourceGroupName = extractResourceGroupName(*vm.ID) // Extract if not specified
+			}
 			match := true
 			for key, value := range tags {
 				if vmValue, ok := vm.Tags[key]; !ok || *vmValue != value {
@@ -289,17 +296,20 @@ func (a *AzureProvider) GetServerBank(tags map[string]string) (*ServerBank, erro
 					return nil, fmt.Errorf("failed to get instance view: %v", err)
 				}
 
-				var status string
+				var powerState string
 				for _, s := range instanceView.Statuses {
-					if s.Code != nil {
-						status = normalizeStatus(*s.Code)
+					if s.Code != nil && strings.HasPrefix(*s.Code, "PowerState/") {
+						powerState = *s.Code
+						break
 					}
 				}
+				status := normalizeStatus(powerState)
 
 				server := &Server{
-					ID:     vm.ID,
-					Name:   *vm.Name,
-					Status: status,
+					ID:                vm.ID,
+					Name:              *vm.Name,
+					Status:            status,
+					ResourceGroupName: resourceGroupName,
 				}
 				serverBank.Servers = append(serverBank.Servers, server)
 			}
@@ -312,6 +322,16 @@ func (a *AzureProvider) GetServerBank(tags map[string]string) (*ServerBank, erro
 	})
 
 	return serverBank, nil
+}
+
+func extractResourceGroupName(vmID string) string {
+	parts := strings.Split(vmID, "/")
+	for i, part := range parts {
+		if part == "resourceGroups" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }
 
 // GetStatus returns the overall status of the server bank.
@@ -335,11 +355,11 @@ func (sb *ServerBank) GetStatus() string {
 func normalizeStatus(azureStatus string) string {
 	switch azureStatus {
 	case "PowerState/running":
-		return "running" // Similar to AWS 'running'
+		return string(types.InstanceStateNameRunning)
 	case "PowerState/stopped", "PowerState/deallocated":
-		return "stopped" // Similar to AWS 'stopped'
+		return string(types.InstanceStateNameStopped)
 	default:
-		return "pending" // A generic catch-all similar to AWS 'pending' or 'stopping'
+		return string(types.InstanceStateNamePending)
 	}
 }
 
@@ -408,8 +428,8 @@ func (a *AzureProvider) PowerOnAll(sb *ServerBank) error {
 	ctx := context.TODO()
 
 	for _, server := range sb.Servers {
-		if server.Status == string(types.InstanceStateNameStopped) { // Check the exact stopped state code for Azure
-			_, err := a.vmClient.BeginStart(ctx, resourceGroupName, server.Name, nil)
+		if server.Status == string(types.InstanceStateNameStopped) {
+			_, err := a.vmClient.BeginStart(ctx, server.ResourceGroupName, server.Name, nil)
 			if err != nil {
 				return fmt.Errorf("failed to start VM %s: %v", server.Name, err)
 			}
@@ -424,8 +444,8 @@ func (a *AzureProvider) PowerOffAll(sb *ServerBank) error {
 	ctx := context.TODO()
 
 	for _, server := range sb.Servers {
-		if server.Status == string(types.InstanceStateNameRunning) { // Check the exact running state code for Azure
-			_, err := a.vmClient.BeginDeallocate(ctx, resourceGroupName, server.Name, nil)
+		if server.Status == string(types.InstanceStateNameRunning) {
+			_, err := a.vmClient.BeginDeallocate(ctx, server.ResourceGroupName, server.Name, nil)
 			if err != nil {
 				return fmt.Errorf("failed to stop VM %s: %v", server.Name, err)
 			}
@@ -553,10 +573,6 @@ func serve() {
 		subscriptionID = viper.GetString("subscription-id")
 		if subscriptionID == "" {
 			log.Fatal("Azure subscription ID is required when using Azure provider.")
-		}
-		resourceGroupName = viper.GetString("resource-group-name")
-		if resourceGroupName == "" {
-			log.Fatal("Azure resource group name is required when using Azure provider.")
 		}
 		client, err := getVMClient(subscriptionID)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 	rootCmd.Flags().String("favicon", "", "path to favicon")
 	rootCmd.Flags().Duration("read-header-timeout", defaultReadHeaderTimeout, "timeout for reading the request headers")
 	rootCmd.Flags().String("provider", "aws", "cloud provider (aws or azure)")
-	rootCmd.Flags().String("resource-group-name", "", "optional resource group name filter (valid only for Azure)")
+	rootCmd.Flags().String("resource-group-name", "", "filter instances based on their resource group membership (only used with the Azure provider)")
 	rootCmd.Flags().String("subscription-id", "", "subscription ID (valid only for Azure)")
 
 	err := viper.BindPFlags(rootCmd.Flags())


### PR DESCRIPTION
This PR addresses issues identified when a status other than PowerState/ is returned, which results in a permanent 'pending' state on the frontend. To resolve this, additional checks have been implemented. Furthermore, this PR enables dynamic querying of the resource group once the subscription ID is provided. However, users still have the option to specify a resource group, which remains an optional parameter. 

### Test plan:
1. Build the go files
`go build .`
2. Run without a resource group name
`./river-guide --provider azure --subscription-id <id>`
3. Run with a resource group name filter
`./river-guide --provider azure --resource-group-name FRGAPAC2 --subscription-id <id>`

Updated HTML tags to distinguish providers and resource groups specified:
![image](https://github.com/frgrisk/river-guide/assets/58250257/694616ab-387b-4c99-80af-a3d47233ba28)
![image](https://github.com/frgrisk/river-guide/assets/58250257/be4bb73e-01e5-492a-8b7a-7f2004edefad)
![image](https://github.com/frgrisk/river-guide/assets/58250257/0f9ccdb2-8eb0-4807-aa53-deb996c11585)
