### PR TITLE
feat: display API errors as alerts in the UI

### DIFF
--- a/cmd/assets/index.gohtml
+++ b/cmd/assets/index.gohtml
@@ -182,13 +182,24 @@
 <script>
 	async function fetchFromServer(url, method = 'GET', body = null) {
 		const response = await fetch(url, { method, body });
-		if (!response.ok) throw new Error('Network response was not ok');
+		if (!response.ok) {
+			// Parse the response body as text
+			const errorText = await response.text();
+			throw new Error(errorText || 'Network response was not ok');
+		}
 		return await response.text();
 	}
 
 	async function toggleServer() {
+	  try {
 		await fetchFromServer("{{ .TogglePath }}", "POST");
 		location.reload();
+	  } catch (error) {
+		// Display the error message to the user in some way
+		alert(error.message);
+		// Refresh the page after the alert is acknowledged
+		location.reload();
+	  }
 	}
 </script>
 {{end}}


### PR DESCRIPTION
## Summary

Sometimes when there are spot interruptions and instances cannot be started, the page will silently "eat" errors when trying to start instances. This is a quick change to at least return the API error as an alert to give an idea of what the problem is.

Better formatting and capturing of these errors should be added in future PRs.

## Test Plan

Use AWSReadOnlyAccess IAM credentials to start up an instance of river-guide. The page should load fine. Attempt to start the instances. You should receive an alert like this:

![image](https://github.com/frgrisk/river-guide/assets/16367391/fac8fd19-8a56-433b-8a61-b47ffa684f5d)
