### PR TITLE
Fix concurrency wait and header order

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -239,7 +239,7 @@ func (h *AWSProvider) PowerOnRDSInstances(servers []*Server) error {
 			return nil
 		})
 	}
-	return nil
+	return g.Wait()
 }
 
 // PowerOffAll powers off all the servers in the bank and updates their statuses.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -405,11 +405,11 @@ var favicon []byte
 
 func FaviconHandler(w http.ResponseWriter, r *http.Request) {
 	if viper.GetString("favicon") == "" {
+		w.WriteHeader(http.StatusOK)
 		_, err := w.Write(favicon)
 		if err != nil {
 			panic(err)
 		}
-		w.WriteHeader(http.StatusOK)
 		return
 	}
 	http.ServeFile(w, r, viper.GetString("favicon"))


### PR DESCRIPTION
## Summary
- ensure RDS start waits for goroutines to finish
- send headers before writing favicon