### PR TITLE
Fix comment about ServerBank

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -169,7 +169,7 @@ type Server struct {
 	Type              ServerType
 }
 
-// ServerBank represents a bank of AWS servers.
+// ServerBank represents a bank of servers.
 type ServerBank struct {
 	Servers []*Server
 }


### PR DESCRIPTION
## Summary
- reword ServerBank comment to indicate multiple provider support

## Testing
- `npx prettier --check .`
- `golangci-lint run`
- `go test ./...`
- `go build ./...`
